### PR TITLE
fix: Patches breaking due to blank characters

### DIFF
--- a/build_revanced.sh
+++ b/build_revanced.sh
@@ -9,10 +9,11 @@ excluded_start="$(grep -n -m1 'EXCLUDE PATCHES' "$patch_file" | cut -d':' -f1)"
 included_start="$(grep -n -m1 'INCLUDE PATCHES' "$patch_file" | cut -d':' -f1)"
 
 # Get everything but hashes from between the EXCLUDE PATCH & INCLUDE PATCH line
-excluded_patches="$(tail -n +$excluded_start $patch_file | head -n "$(( included_start - excluded_start ))" | grep '^[^#]')"
+# Note: '^[^#[:blank:]]' ignores starting hashes and/or blank characters i.e, whitespace & tab excluding newline
+excluded_patches="$(tail -n +$excluded_start $patch_file | head -n "$(( included_start - excluded_start ))" | grep '^[^#[:blank:]]')"
 
 # Get everything but hashes starting from INCLUDE PATCH line until EOF
-included_patches="$(tail -n +$included_start $patch_file | grep '^[^#]')"
+included_patches="$(tail -n +$included_start $patch_file | grep '^[^#[:blank:]]')"
 
 # Array for storing patches
 declare -a patches


### PR DESCRIPTION
Apparently, blank characters were causing the script to break. If any user
added a whitespace or tab after adding patches in patches.txt, it was counted
as a valid patch because our grep regexp was only ignoring hashes & not
whitespace & tabs.
I am quite surprised we didn't catch this before. Anyway, regexp has been modified
to ignore blank characters as well as hashes.

Now users can fill the patches.txt with blank characters as much as they want
without their scrip breaking

Closes #46 