### PR TITLE
workflows: Switch to Temurin 17 JDK

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -11,10 +11,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Download APKs from APKMirror
         run: ./download_apkmirror.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Download APKs from APKMirror
         run: ./download_apkmirror.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.9.0
         with:
           java-version: "17"
-          distribution: "adopt"
+          distribution: "temurin"
 
       - name: Download APKs from APKMirror
         run: ./download_apkmirror.sh


### PR DESCRIPTION
[1]: AdoptOpenJDK got moved to Eclipse Temurin and won't be updated anymore. [2]: Uprev actions/setup-java along with it

Reference: https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/

Signed-off-by: taalojarvi <sreedevan05@gmail.com>