### PR TITLE
fix: new integration filename

### DIFF
--- a/build_revanced.sh
+++ b/build_revanced.sh
@@ -22,7 +22,7 @@ declare -a patches
 declare -A artifacts
 
 artifacts["revanced-cli.jar"]="revanced/revanced-cli revanced-cli .jar"
-artifacts["revanced-integrations.apk"]="revanced/revanced-integrations app-release-unsigned .apk"
+artifacts["revanced-integrations.apk"]="revanced/revanced-integrations revanced-integrations .apk"
 artifacts["revanced-patches.jar"]="revanced/revanced-patches revanced-patches .jar"
 artifacts["apkeep"]="EFForg/apkeep apkeep-x86_64-unknown-linux-gnu"
 


### PR DESCRIPTION
ReVanced integration commits https://github.com/revanced/revanced-integrations/commit/4c18633c364491a1d699f92f1bc519517632d709 and https://github.com/revanced/revanced-integrations/commit/bc635a79c59d5d58183975cf18b4199c860040b6 renamed integration apk from `app-release-unsigned.apk` to `revanced-integrations-$versionName.apk`. This PR addresses the issue accordingly