### PR TITLE
build_revanced.sh: Track inotia00's fork of Vanced-MicroG

### DIFF
--- a/build_revanced.sh
+++ b/build_revanced.sh
@@ -23,6 +23,7 @@ declare -A artifacts
 
 artifacts["revanced-cli.jar"]="revanced/revanced-cli revanced-cli .jar"
 artifacts["revanced-integrations.apk"]="revanced/revanced-integrations revanced-integrations .apk"
+artifacts["vanced-microG.apk"]="inotia00/VancedMicroG microg .apk"
 artifacts["revanced-patches.jar"]="revanced/revanced-patches revanced-patches .jar"
 artifacts["apkeep"]="EFForg/apkeep apkeep-x86_64-unknown-linux-gnu"
 


### PR DESCRIPTION
Vanced MicroG is outdated.

Track @inotia00 's fork so that we can maintain an updated version of MicroG until ReVanced decides to maintain their own fork.

This PR is a clone of https://github.com/n0k0m3/revanced-build-template/pull/71 which seems to be abandoned by the PR maintainer.