### PR TITLE
workflows: Set write permissions for the GitHub token contents

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: ReVanced Build
 on:
   workflow_dispatch:
 
+permissions:
+   contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is necessary because, otherwise, marvinpinto/action-automatic-releases@latest would fail with the following error:  Attempting to create or update release tag "latest"
  Could not create new tag "refs/tags/latest" (Resource not accessible by integration) therefore updating existing tag "tags/latest"