### PR TITLE
versions: Bump YT version

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,5 @@
 {
-    "com.google.android.youtube.apk": "18.15.40",
+    "com.google.android.youtube.apk": "18.16.37",
     "com.google.android.apps.youtube.music.apk": "5.52.51",
     "com.zhiliaoapp.musically.apk": "27.8.3",
     "tv.twitch.android.app.apk": "14.6.1"

--- a/versions_extended.json
+++ b/versions_extended.json
@@ -1,5 +1,5 @@
 {
-    "com.google.android.youtube.apk": "18.05.40",
+    "com.google.android.youtube.apk": "18.17.43",
     "com.google.android.apps.youtube.music.apk": "6.01.56",
     "com.zhiliaoapp.musically.apk": "27.8.3",
     "tv.twitch.android.app.apk": "14.6.1"


### PR DESCRIPTION
YouTube ReVanced is now at version 18.16.37

YouTube ReVanced Extended is now at version 18.17.43

